### PR TITLE
Fix: filtered objects should not be visible

### DIFF
--- a/src/js/gfx/solar/SolarParticles.ts
+++ b/src/js/gfx/solar/SolarParticles.ts
@@ -188,7 +188,7 @@ export class SolarParticles {
         const attr = this.mesh.geometry.attributes.filterValue;
         const arr = attr.array;
         for(let i=0;i<this._data.length; i++) {
-            arr[i] = this.filtered[i] ? .1 : 1;
+            arr[i] = this.filtered[i] ? 0 : 1;
         }
 
         attr.needsUpdate = true;


### PR DESCRIPTION
resolves #43

By setting the filtered value to 0 instead of 0.1 we indicate to the renderer that the particle should not be rendered at all, instead of just rendered with reduced opacity.