### PR TITLE
fix: update the filter value so filtered objects are not rendered

### DIFF
--- a/src/js/gfx/solar/SolarParticles.ts
+++ b/src/js/gfx/solar/SolarParticles.ts
@@ -188,7 +188,7 @@ export class SolarParticles {
         const attr = this.mesh.geometry.attributes.filterValue;
         const arr = attr.array;
         for(let i=0;i<this._data.length; i++) {
-            arr[i] = this.filtered[i] ? .1 : 1;
+            arr[i] = this.filtered[i] ? 0 : 1;
         }
 
         attr.needsUpdate = true;


### PR DESCRIPTION
By setting the filtered value to 0 instead of 0.1 we indicate in the fragment shader that filtered particles should be fully discarded rather than just reducing the opacity.